### PR TITLE
Removing duplicate dependency, listing version restrictions as in the library

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @hmaarrfk
+* @hmaarrfk @tdegeus

--- a/README.md
+++ b/README.md
@@ -9,6 +9,10 @@ Feedstock license: [BSD-3-Clause](https://github.com/conda-forge/sphinx-mdinclud
 
 Summary: Sphinx extension for including or writing pages in Markdown format.
 
+Development: https://github.com/omnilib/sphinx-mdinclude
+
+Documentation: https://sphinx-mdinclude.readthedocs.io
+
 Current build status
 ====================
 
@@ -144,4 +148,5 @@ Feedstock Maintainers
 =====================
 
 * [@hmaarrfk](https://github.com/hmaarrfk/)
+* [@tdegeus](https://github.com/tdegeus/)
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,9 +1,6 @@
 {% set version = "0.5.3" %}
 
 package:
-  # pypi package uses underscore. however, I believe that conda-forge
-  # prefers dashes
-  # https://pypi.org/project/sphinx_mdinclude/
   name: sphinx-mdinclude
   version: {{ version }}
 
@@ -12,34 +9,28 @@ source:
   sha256: 2998e3d18b3022c9983d1b72191fe37e25ffccd54165cbe3acb22cceedd91af4
 
 build:
+  number: 1
   noarch: python
-  script:
-    # - rm -f pyproject.toml
-    - {{ PYTHON }} -m pip install . -vv
-  number: 0
+  script: {{ PYTHON }} -m pip install . -vv
 
 requirements:
   host:
     - python >=3.8
     - pip
-    - flit-core
-    # flit seems to import things, so duplicate all dependencies here
-    - mistune >=2.0,<3.0.0.0a
-    - docutils >=0.16,<1.0.0a
+    - mistune >=2.0,<3.0
+    - docutils >=0.16,<1.0
     - pygments >=2.8
-    - docutils
   run:
     - python >=3.8
-    - mistune >=2.0,<3.0.0.0a
-    - docutils >=0.16,<1.0.0a
+    - mistune >=2.0,<3.0
+    - docutils >=0.16,<1.0
     - pygments >=2.8
-    - docutils
 
 test:
-  imports:
-    - sphinx_mdinclude
   requires:
     - pip
+  imports:
+    - sphinx_mdinclude
   commands:
     - pip check
 
@@ -49,7 +40,10 @@ about:
   license: MIT
   license_family: MIT
   license_file: LICENSE
+  doc_url: https://sphinx-mdinclude.readthedocs.io
+  dev_url: https://github.com/omnilib/sphinx-mdinclude
 
 extra:
   recipe-maintainers:
     - hmaarrfk
+    - tdegeus

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -17,6 +17,7 @@ requirements:
   host:
     - python >=3.8
     - pip
+    - flit-core
     - mistune >=2.0,<3.0
     - docutils >=0.16,<1.0
     - pygments >=2.8


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->

Hi,

I'm getting a mysterious issue on read the docs: 
```
[rtd-command-info] start-time: 2022-12-30T08:08:46.849635Z, end-time: 2022-12-30T08:08:46.913865Z, duration: 0, exit-code: 0
cat environment.yaml
channels:
- conda-forge
dependencies:
- furo
- numpy
- python
- sphinx-mdinclude
- pip:
  - recommonmark
  - readthedocs-sphinx-ext
- mock
- pillow
- sphinx
- sphinx_rtd_theme

[rtd-command-info] start-time: 2022-12-30T08:08:47.161658Z, end-time: 2022-12-30T08:10:29.081381Z, duration: 101, exit-code: 1
conda env create --quiet --name latest --file environment.yaml
Warning: you have pip-installed dependencies in your environment file, but you do not list pip itself as one of your conda dependencies.  Conda may not use the correct pip to install your packages, and they may end up in the wrong place.  Please add an explicit pip dependency.  I'm adding one for you, but still nagging you.
Collecting package metadata: ...working... done
Solving environment: ...working... failed

ResolvePackageNotFound: 
  - sphinx-mdinclude
```
see  https://readthedocs.org/api/v2/build/19037290.txt .

So that made me browse over here. I did notice a duplicate dependency and some version limits that were different that in the library. I don't think it will solve my issue, but still here is my proposal to fix
